### PR TITLE
Fix `Usage` type for runs

### DIFF
--- a/src/OpenAI/V1/Threads/Runs.hs
+++ b/src/OpenAI/V1/Threads/Runs.hs
@@ -209,7 +209,7 @@ data RunObject = RunObject
     , instructions :: Maybe Text
     , tools :: Vector Tool
     , metadata :: Map Text Text
-    , usage :: Maybe (Usage (Maybe Void) (Maybe Void))
+    , usage :: Maybe (Usage (Maybe CompletionTokensDetails) (Maybe PromptTokensDetails))
     , temperature :: Maybe Double
     , top_p :: Maybe Double
     , max_prompt_tokens :: Maybe Natural

--- a/src/OpenAI/V1/Usage.hs
+++ b/src/OpenAI/V1/Usage.hs
@@ -36,4 +36,4 @@ data Usage completionTokensDetails promptTokensDetails = Usage
     } deriving stock (Generic, Show)
 
 instance FromJSON (Usage CompletionTokensDetails PromptTokensDetails)
-instance FromJSON (Usage (Maybe Void) (Maybe Void))
+instance FromJSON (Usage (Maybe CompletionTokensDetails) (Maybe PromptTokensDetails))


### PR DESCRIPTION
It *can* have the details present.  They are not necessarily absent