### PR TITLE
Add reasoning effort to Chat Completions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.2:
+
+- Add support for `reasoning_effort` parameter in chat completions
+
 1.0.1:
 
 - Include `README`

--- a/openai.cabal
+++ b/openai.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               openai
-version:            1.0.1
+version:            1.0.2
 synopsis:           Servant bindings to OpenAI
 description:        This package provides comprehensive and type-safe bindings
                     to OpenAI, providing both a Servant interface and

--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -21,6 +21,7 @@ module OpenAI.V1.Chat.Completions
     , AudioParameters(..)
     , ResponseFormat(..)
     , ServiceTier(..)
+    , ReasoningEffort(..)
     , FinishReason(..)
     , Token(..)
     , LogProbs(..)
@@ -195,6 +196,15 @@ instance FromJSON ServiceTier where
 instance ToJSON ServiceTier where
     toJSON = genericToJSON aesonOptions
 
+data ReasoningEffort = Low | Medium | High
+    deriving stock (Generic, Show)
+
+instance FromJSON ReasoningEffort where
+    parseJSON = genericParseJSON aesonOptions
+
+instance ToJSON ReasoningEffort where
+    toJSON = genericToJSON aesonOptions
+
 -- | Request body for @\/v1\/chat\/completions@
 data CreateChatCompletion = CreateChatCompletion
     { messages :: Vector (Message (Vector Content))
@@ -211,6 +221,7 @@ data CreateChatCompletion = CreateChatCompletion
     , prediction :: Maybe Prediction
     , audio :: Maybe AudioParameters
     , presence_penalty :: Maybe Double
+    , reasoning_effort :: Maybe ReasoningEffort
     , response_format :: Maybe ResponseFormat
     , seed :: Maybe Integer
     , service_tier :: Maybe (AutoOr ServiceTier)
@@ -241,6 +252,7 @@ _CreateChatCompletion = CreateChatCompletion
     , prediction = Nothing
     , audio = Nothing
     , presence_penalty = Nothing
+    , reasoning_effort = Nothing
     , response_format = Nothing
     , seed = Nothing
     , service_tier = Nothing
@@ -295,6 +307,7 @@ data ChatCompletionObject = ChatCompletionObject
     , choices :: Vector Choice
     , created :: POSIXTime
     , model :: Model
+    , reasoning_effort :: Maybe ReasoningEffort
     , service_tier :: Maybe ServiceTier
     , system_fingerprint :: Text
     , object :: Text

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -89,7 +89,7 @@ main = do
 
     let user = "openai Haskell package"
     let chatModel = "gpt-4o-mini"
-
+    let reasoningModel = "o3-mini"
     let Methods{..} = V1.makeMethods clientEnv (Text.pack key)
 
     -- Test each format to make sure we're handling each possible content type
@@ -153,6 +153,42 @@ main = do
                     , prediction = Nothing
                     , audio = Nothing
                     , presence_penalty = Nothing
+                    , reasoning_effort = Nothing
+                    , response_format = Nothing
+                    , seed = Nothing
+                    , service_tier = Nothing
+                    , stop = Nothing
+                    , temperature = Nothing
+                    , top_p = Nothing
+                    , tools = Nothing
+                    , tool_choice = Nothing
+                    , parallel_tool_calls = Nothing
+                    , user = Nothing
+                    }
+
+                return ()
+
+    let completionsMinimalReasoningTest =
+            HUnit.testCase "Create chat completion reasoning model - minimal" do
+                _ <- createChatCompletion CreateChatCompletion
+                    { messages =
+                        [ Completions.User
+                            { content = [ "Hello, world!" ], name = Nothing }
+                        ]
+                    , model = reasoningModel
+                    , store = Nothing
+                    , metadata = Nothing
+                    , frequency_penalty = Nothing
+                    , logit_bias = Nothing
+                    , logprobs = Nothing
+                    , top_logprobs = Nothing
+                    , max_completion_tokens = Nothing
+                    , n = Nothing
+                    , modalities = Nothing
+                    , prediction = Nothing
+                    , audio = Nothing
+                    , presence_penalty = Nothing
+                    , reasoning_effort = Just Completions.Low
                     , response_format = Nothing
                     , seed = Nothing
                     , service_tier = Nothing
@@ -208,6 +244,7 @@ main = do
                     , prediction = Nothing
                     , audio = Nothing
                     , presence_penalty = Just 0
+                    , reasoning_effort = Nothing
                     , response_format = Just Completions.ResponseFormat_Text
                     , seed = Just 0
                     , service_tier = Just Auto
@@ -632,6 +669,7 @@ main = do
             <>  [ transcriptionTest
                 , translationTest
                 , completionsMinimalTest
+                , completionsMinimalReasoningTest
                 , completionsMaximalTest
                 , embeddingsTest
                 , fineTuningTest


### PR DESCRIPTION
Constrains effort on reasoning for [reasoning models](https://platform.openai.com/docs/guides/reasoning). Currently supported values are low, medium, and high.

https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort