### PR TITLE
Make System Fingerprint optional

### DIFF
--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -335,7 +335,7 @@ data ChatCompletionObject = ChatCompletionObject
     , model :: Model
     , reasoning_effort :: Maybe ReasoningEffort
     , service_tier :: Maybe ServiceTier
-    , system_fingerprint :: Text
+    , system_fingerprint :: Maybe Text
     , object :: Text
     , usage :: Usage CompletionTokensDetails PromptTokensDetails
     } deriving stock (Generic, Show)


### PR DESCRIPTION
requests to some Chat Completions API compatible endpoints (Anthropic) omit the `system_fingerprint` parameter; resulting in:

```
"DecodeFailure \"Error in $: parsing OpenAI.V1.Chat.Completions.ChatCompletionObject(ChatCompletionObject) failed, key \\\"system_fingerprint\\\" not found\"
```