### PR TITLE
Additional optional fields in the Usage object

### DIFF
--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -335,7 +335,7 @@ data ChatCompletionObject = ChatCompletionObject
     , model :: Model
     , reasoning_effort :: Maybe ReasoningEffort
     , service_tier :: Maybe ServiceTier
-    , system_fingerprint :: Text
+    , system_fingerprint :: Maybe Text
     , object :: Text
     , usage :: Usage CompletionTokensDetails PromptTokensDetails
     } deriving stock (Generic, Show)

--- a/src/OpenAI/V1/Usage.hs
+++ b/src/OpenAI/V1/Usage.hs
@@ -31,8 +31,8 @@ data Usage completionTokensDetails promptTokensDetails = Usage
     { completion_tokens :: Natural
     , prompt_tokens :: Natural
     , total_tokens :: Natural
-    , completion_tokens_details :: completionTokensDetails
-    , prompt_tokens_details :: promptTokensDetails
+    , completion_tokens_details :: Maybe completionTokensDetails
+    , prompt_tokens_details :: Maybe promptTokensDetails
     } deriving stock (Generic, Show)
 
 instance FromJSON (Usage CompletionTokensDetails PromptTokensDetails)


### PR DESCRIPTION
follow up to https://github.com/MercuryTechnologies/openai/pull/50

some `usage` fields should be optional as some API endpoints omit these

```
"DecodeFailure \"Error in $.usage: parsing OpenAI.V1.Usage.Usage(Usage) failed, key \\\"completion_tokens_details\\\" not found\"
```