### PR TITLE
Allow Custom Headers

### DIFF
--- a/openai.cabal
+++ b/openai.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               openai
-version:            1.1.0
+version:            1.2.0
 synopsis:           Servant bindings to OpenAI
 description:        This package provides comprehensive and type-safe bindings
                     to OpenAI, providing both a Servant interface and
@@ -27,11 +27,15 @@ library
                       , bytestring
                       , containers
                       , filepath
+                      , http-client
+                      , http-types
                       , http-api-data
                       , http-client-tls
+                      , zlib < 0.7
                       , servant
                       , servant-multipart-api
                       , servant-client
+                      , servant-client-core
                       , servant-multipart-client
                       , text
                       , time
@@ -104,8 +108,11 @@ test-suite tasty
                     , aeson
                     , http-client
                     , http-client-tls
+                    , http-types
+                    , zlib < 0.7
                     , openai
                     , servant-client
+                    , servant-client-core
                     , tasty
                     , tasty-hunit
                     , text

--- a/src/OpenAI/V1.hs
+++ b/src/OpenAI/V1.hs
@@ -165,9 +165,9 @@ getClientEnv baseUrlText = do
 -- | Augment a 'ClientEnv' so that every outgoing HTTP request includes the
 -- given headers.
 --
--- This is useful for custom tracing / billing headers such as
+-- This is useful for custom tracing / proxy headers such as
 --
--- > setExtraHeaders [("x-bt-parent", "project_id:abc123")]
+-- > setExtraHeaders [("x-parent", "project_id:abc123")]
 --
 -- You can pipe the modified environment straight into 'makeMethods':
 --


### PR DESCRIPTION
One way is to offer a pure function:
```hs
setExtraHeaders :: RequestHeaders -> ClientEnv -> ClientEnv
```
Internally it tweaks `makeClientRequest` in the `ClientEnv` so every outgoing request gains those headers. Users do:

```hs
env  <- getClientEnv "https://api.openai.com"
env' <- pure (setExtraHeaders extra env)
let Methods{..} = makeMethods env' token
```

No new public types, no need to touch every call‑site.
Exploratory "what would this look like" type draft PR. 