### PR TITLE
Fix few 'cabal check' warnings

### DIFF
--- a/openai.cabal
+++ b/openai.cabal
@@ -14,10 +14,15 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Gabriella Gonzalez
 maintainer:         GenuineGabriella@gmail.com
+category:           AI, API, Web
 copyright:          2024 Gabriella Gonzalez
 build-type:         Simple
-extra-source-files: CHANGELOG.md
-                    README.md
+extra-doc-files:    CHANGELOG.md
+extra-source-files: README.md
+
+source-repository head
+  type:             git
+  location:         https://github.com/MercuryTechnologies/openai
 
 library
     default-language:   Haskell2010


### PR DESCRIPTION
Thank you for this nice and cleanly structured api binding project, it's pleasure to read :smiley: 

Could you please add source repo url to cabal file (for ease of navigation from hackage to github)?
The missing source-repo field shows up as part of 
<details>
  <summary>cabal check warnings (click to expand)</summary>
  <pre>
cabal check
These warnings will likely cause trouble when distributing the package:
Warning: [no-repository] When distributing packages, it is encouraged to
specify source control information in the .cabal file using one or more
'source-repository' sections. See the Cabal user guide for details.
Warning: [no-category] No 'category' field.
These warnings may cause trouble when distributing the package:
Warning: [doc-place] Please consider moving the file 'CHANGELOG.md' from the
'extra-source-files' section of the .cabal file to the section
'extra-doc-files'.
Warning: [missing-upper-bounds] On library, these packages miss upper bounds:
- aeson
- bytestring
- containers
- filepath
- http-api-data
- http-client-tls
- servant
- servant-multipart-api
- servant-client
- servant-multipart-client
- text
- time
- vector
Please add them. There is more information at https://pvp.haskell.org/

  </pre>
</details>
so I fixed it along with few other minor warnings.