### PR TITLE
Use a simple type for ServiceTier

### DIFF
--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -207,17 +207,7 @@ data AudioParameters = AudioParameters
       deriving anyclass (FromJSON, ToJSON)
 
 -- | Specifies the latency tier to use for processing the request
-data ServiceTier = Default
-    deriving stock (Generic, Show)
-
-serviceOptions :: Options
-serviceOptions = aesonOptions{ tagSingleConstructors = True }
-
-instance FromJSON ServiceTier where
-    parseJSON = genericParseJSON serviceOptions
-
-instance ToJSON ServiceTier where
-    toJSON = genericToJSON serviceOptions
+type ServiceTier = Text
 
 -- | Constrains effort on reasoning for reasoning models
 data ReasoningEffort


### PR DESCRIPTION
(Just testing for now, don't merge yet please)

Fix for arbitrary service tiers provided by various model providers. 



E.g. 

* OpenAI has `'flex'` which is not supported right now.
* Groq defaults to `'on_demand'`, which causes the following exception:

```
Exception: DecodeFailure "Error in $['service_tier']: parsing OpenAI.V1.Chat.Completions.ServiceTier failed, expected one of the tags [\"default\"], but found tag \"on_demand\""
```