### PR TITLE
Add support for `OpenAI-{Organization,Project}` headers

### DIFF
--- a/examples/openai-example/Main.hs
+++ b/examples/openai-example/Main.hs
@@ -19,7 +19,7 @@ main = do
 
     clientEnv <- getClientEnv "https://api.openai.com"
 
-    let Methods{ createChatCompletion } = makeMethods clientEnv (Text.pack key)
+    let Methods{ createChatCompletion } = makeMethods clientEnv (Text.pack key) Nothing Nothing
 
     text <- Text.IO.getLine
 

--- a/examples/weather-chatbot-example/Main.hs
+++ b/examples/weather-chatbot-example/Main.hs
@@ -214,7 +214,7 @@ main = do
 
   -- Set up client
   clientEnv <- getClientEnv "https://api.openai.com"
-  let Methods {createChatCompletion} = makeMethods clientEnv (Text.pack key)
+  let Methods {createChatCompletion} = makeMethods clientEnv (Text.pack key) Nothing Nothing
 
   -- Initial system message
   let systemMessage =

--- a/src/OpenAI/Prelude.hs
+++ b/src/OpenAI/Prelude.hs
@@ -31,13 +31,13 @@ module OpenAI.Prelude
 import Data.ByteString.Lazy (ByteString)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
+import Data.String (IsString(..))
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import Data.Vector (Vector)
 import Data.Void (Void)
-import GHC.Generics (Generic)
-import Data.String (IsString(..))
 import Data.Word (Word8)
+import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 import Web.HttpApiData (ToHttpApiData(..))
 
@@ -59,6 +59,7 @@ import Servant.API
     , JSON
     , MimeUnrender(..)
     , OctetStream
+    , Optional
     , Post
     , QueryParam
     , ReqBody

--- a/src/OpenAI/V1.hs
+++ b/src/OpenAI/V1.hs
@@ -168,8 +168,12 @@ makeMethods
     -- ^
     -> Text
     -- ^ API token
+    -> Maybe Text
+    -- ^ Organization ID
+    -> Maybe Text
+    -- ^ Project ID
     -> Methods
-makeMethods clientEnv token = Methods{..}
+makeMethods clientEnv token organizationID projectID = Methods{..}
   where
     authorization = "Bearer " <> token
 
@@ -272,7 +276,7 @@ makeMethods clientEnv token = Methods{..}
                 :<|>  listVectorStoreFilesInABatch_
                 )
             )
-      ) = Client.hoistClient @API Proxy run (Client.client @API Proxy) authorization
+      ) = Client.hoistClient @API Proxy run (Client.client @API Proxy) authorization organizationID projectID
 
     run :: Client.ClientM a -> IO a
     run clientM = do
@@ -530,6 +534,8 @@ data Methods = Methods
 -- | Servant API
 type API
     =   Header' [ Required, Strict ] "Authorization" Text
+    :>  Header' [ Optional, Strict ] "OpenAI-Organization" Text
+    :>  Header' [ Optional, Strict ] "OpenAI-Project" Text
     :>  "v1"
     :>  (     Audio.API
         :<|>  Chat.Completions.API

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -118,7 +118,7 @@ main = do
   let chatModel = "gpt-4o-mini"
   let reasoningModel = "o3-mini"
   let ttsModel = "tts-1"
-  let Methods {..} = V1.makeMethods clientEnv (Text.pack key)
+  let Methods {..} = V1.makeMethods clientEnv (Text.pack key) Nothing Nothing
 
   -- Test each format to make sure we're handling each possible content type
   -- correctly


### PR DESCRIPTION
For example, this comes in handy if you want to ensure that a user doesn't use their personal API key to make a request that should only belong within an enterprise's organization (in order to guarantee certain data privacy guarantees).